### PR TITLE
Fixing and improving the CPunishController

### DIFF
--- a/src/antibob/bob/antibob.cpp
+++ b/src/antibob/bob/antibob.cpp
@@ -219,8 +219,12 @@ void CAntibob::RconEvents(int ClientId)
 bool CAntibob::OnSayNetMessage(const polybob::CNetMsg_Cl_Say *pMsg, int ClientId, const polybob::CUnpacker *pUnpacker)
 {
 	if(str_find_nocase(pMsg->m_pMessage, "i am using a cheat client"))
-		if(Config()->m_AbAutoKick)
-			Kick(ClientId, Config()->m_AbKickReason[0] ? Config()->m_AbKickReason : "self report");
+	{
+		if(Config()->m_AbAutoPunishment >= 2)
+			Ban(ClientId, Config()->m_AbAutoPunishment, Config()->m_AbPunishmentReason[0] ? Config()->m_AbPunishmentReason : "self report");
+		else if(Config()->m_AbAutoPunishment == 1)
+			Kick(ClientId, Config()->m_AbPunishmentReason[0] ? Config()->m_AbPunishmentReason : "self report");
+	}
 	if(str_find_nocase(pMsg->m_pMessage, "i hack"))
 		Detect(ClientId, BOB_DE_SELFREPORT, "said 'i hack'");
 	// if(str_find_nocase(pMsg->m_pMessage, "uwu"))

--- a/src/antibob/bob/config_variables.h
+++ b/src/antibob/bob/config_variables.h
@@ -22,8 +22,8 @@ MACRO_CONFIG_STR(SvName, sv_name, 128, "unnamed server", CFGFLAG_SERVER, "Server
 
 // antibot internal variables are conventionally prefixed with ab
 // short for anti bob
-MACRO_CONFIG_INT(AbAutoKick, ab_auto_kick, 1, 0, 100, CFGFLAG_SERVER, "0=off 1=kick 2+=ban time in minutes")
-MACRO_CONFIG_STR(AbKickReason, ab_kick_reason, 64, "antibob auto kick", CFGFLAG_SERVER, "shown to players that get kicked if ab_auto_kick is set")
+MACRO_CONFIG_INT(AbAutoPunishment, ab_auto_punishment, 1, 0, 10000, CFGFLAG_SERVER, "0=off 1=kick 2+=ban time in minutes")
+MACRO_CONFIG_STR(AbPunishmentReason, ab_punishment_reason, 64, "antibob auto punishment", CFGFLAG_SERVER, "shown to players that get kicked if ab_auto_punishment is set")
 MACRO_CONFIG_INT(AbPunishInterval, ab_punish_interval, 120, 1, 600, CFGFLAG_SERVER, "delay in seconds between punish waves")
 MACRO_CONFIG_INT(AbLogEvents, ab_log_events, 0, 0, 1, CFGFLAG_SERVER, "log all suspicious player events into antibob_events.txt in the tw folder (unsafe with multiple servers)")
 MACRO_CONFIG_STR(AbCheaterApiUrl, ab_cheater_api_url, 256, "", CFGFLAG_SERVER, "base url of api that implements GET /player?name=:playername&addr=:ipaddr endpoint has to start with https://")

--- a/src/antibob/bob/gameserver.h
+++ b/src/antibob/bob/gameserver.h
@@ -86,6 +86,11 @@ public:
 
 	// it is recommended to use Punish() instead of Kick()
 	void Kick(int ClientId, const char *pReason = nullptr) const;
+
+	// This is bool because it might not ban
+	bool Ban(int ClientId, int TimeInMinutes, const char *pReason = nullptr);
+	bool Ban(const NETADDR &Ip, int TimeInMinutes, const char *pReason = nullptr);
+
 	void LogInfo(const char *pFormat, ...)
 		GNUC_ATTRIBUTE((format(printf, 2, 3)));
 	void LogError(const char *pFormat, ...)

--- a/src/antibob/bob/pending_punish.cpp
+++ b/src/antibob/bob/pending_punish.cpp
@@ -6,8 +6,8 @@
 
 using namespace polybob;
 
-CPendingPunish::CPendingPunish(int ClientId, const char *pReason, int TimeInMinutes, EPunish Punish) :
-	m_ClientId(ClientId), m_TimeInMinutes(TimeInMinutes), m_Punish(Punish)
+CPendingPunish::CPendingPunish(int ClientId, const NETADDR &Ip, const char *pReason, int TimeInMinutes, EPunish Punish) :
+	m_ClientId(ClientId), m_Ip(Ip), m_TimeInMinutes(TimeInMinutes), m_Punish(Punish)
 {
 	str_copy(m_aReason, pReason);
 }
@@ -18,20 +18,19 @@ void CPunishController::ApplyPunish(CPendingPunish *pPunish)
 		return;
 	pPunish->m_Applied = true;
 
-	char aBuf[512];
 	switch(pPunish->m_Punish)
 	{
 	case CPendingPunish::EPunish::KICK:
 		m_pAntibob->Kick(pPunish->m_ClientId, pPunish->m_aReason);
 		break;
 	case CPendingPunish::EPunish::BAN:
-		str_format(aBuf, sizeof(aBuf), "ban %d %d \"%s\"", pPunish->m_ClientId, pPunish->m_TimeInMinutes, pPunish->m_aReason);
-		if(!m_pAntibob->m_BobAbi.Rcon(aBuf))
-		{
-			log_error("antibob", "antibob rcon abi not supported falling back to kick");
-			m_pAntibob->Kick(pPunish->m_ClientId, pPunish->m_aReason);
-		}
+	{
+		if(m_pAntibob->m_apPlayers[pPunish->m_ClientId])
+			m_pAntibob->Ban(pPunish->m_ClientId, pPunish->m_TimeInMinutes, pPunish->m_aReason);
+		else
+			m_pAntibob->Ban(pPunish->m_Ip, pPunish->m_TimeInMinutes, pPunish->m_aReason);
 		break;
+	}
 	};
 }
 
@@ -62,11 +61,8 @@ void CPunishController::OnPlayerDisconnect(int ClientId)
 		if(Punish.m_ClientId != ClientId)
 			continue;
 
-		// applying kick and ban on disconnect does not work anyways
-		// could get the ip address here and then apply the ban
-		// but it might crash the server
-		// ApplyPunish(&Punish);
-
+		if(Punish.m_Punish == CPendingPunish::EPunish::BAN)
+			ApplyPunish(&Punish);
 		m_vPendingPunishments.erase(m_vPendingPunishments.begin() + i);
 		break;
 	}
@@ -86,10 +82,10 @@ void CPunishController::SchedulePunish(int ClientId, const char *pReason, int Ti
 		return;
 	}
 
-	m_vPendingPunishments.emplace_back(ClientId, pReason, TimeInMinutes, Punish);
+	m_vPendingPunishments.emplace_back(ClientId, m_pAntibob->m_apPlayers[ClientId]->m_Addr, pReason, TimeInMinutes, Punish);
 }
 
-void CPunishController::ListPendingPunishments()
+void CPunishController::ListPendingPunishments() const
 {
 	if(m_vPendingPunishments.empty())
 	{

--- a/src/antibob/bob/pending_punish.h
+++ b/src/antibob/bob/pending_punish.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <polybob/base/types.h>
+
 #include <cstdint>
 #include <vector>
 
@@ -12,9 +14,10 @@ public:
 		BAN,
 	};
 
-	CPendingPunish(int ClientId, const char *pReason, int TimeInMinutes, EPunish Punish);
+	CPendingPunish(int ClientId, const polybob::NETADDR &Ip, const char *pReason, int TimeInMinutes, EPunish Punish);
 
 	int m_ClientId;
+	polybob::NETADDR m_Ip;
 	char m_aReason[512];
 	int m_TimeInMinutes;
 	EPunish m_Punish;
@@ -33,5 +36,5 @@ public:
 	void OnTick();
 	void OnPlayerDisconnect(int ClientId);
 	void SchedulePunish(int ClientId, const char *pReason, int TimeInMinutes, CPendingPunish::EPunish Punish);
-	void ListPendingPunishments();
+	void ListPendingPunishments() const;
 };


### PR DESCRIPTION
[x] Tested in game

```
if(str_find_nocase(pMsg->m_pMessage, "uwu"))
		Punish(ClientId, "no uwu allowed", 1, CPendingPunish::EPunish::BAN);
```

```
2026-01-04 13:15:26 I server: player has entered the game. ClientId=1 addr=<{192.168.88.253:51290}> sixup=0
2026-01-04 13:15:26 I chat: *** '(1)ByFox' entered and joined the blue team with version 19060
2026-01-04 13:15:31 I chat: 1:-2:(1)ByFox: uwu
2026-01-04 13:15:41 I game: kill killer='1:(1)ByFox' victim='1:(1)ByFox' weapon=-3 special=0
2026-01-04 13:15:41 I chat: *** '(1)ByFox' has left the game
2026-01-04 13:15:41 I net_ban: banned <{'192.168.88.253'}> for 1 minute (no uwu allowed)
```