### PR TITLE
AbCheaterApiUrl must support http

### DIFF
--- a/src/antibob/bob/antibob.cpp
+++ b/src/antibob/bob/antibob.cpp
@@ -296,11 +296,11 @@ void CAntibob::LookupPlayer(CAntibotPlayer *pPlayer)
 {
 	if(Config()->m_AbCheaterApiUrl[0] == '\0')
 		return;
-	if(!str_startswith(Config()->m_AbCheaterApiUrl, "https://"))
+	if(!str_startswith(Config()->m_AbCheaterApiUrl, "https://") && !str_startswith(Config()->m_AbCheaterApiUrl, "http://"))
 	{
 		log_error(
 			"antibot",
-			"invalid ab_cheater_api_url value '%s' it is missing the https:// prefix",
+			"invalid ab_cheater_api_url value '%s' it is missing the http(s):// prefix",
 			Config()->m_AbCheaterApiUrl);
 		return;
 	}


### PR DESCRIPTION
I checked that http is working

```
2026-01-04 13:49:47 I server: ClientId=0 key='ByFox' rcon='antibot ab_cheater_api_url "http://127.0.0.1:8080"'
2026-01-04 13:49:49 I security: new client (ddnet token)
2026-01-04 13:49:49 I security: client accepted 192.168.88.253:51290
2026-01-04 13:49:50 I server: player has entered the game. ClientId=1 addr=<{192.168.88.253:51290}> sixup=0
2026-01-04 13:49:50 I chat: *** '(1)ByFox' entered and joined the blue team with version 19060
2026-01-04 13:49:50 I ddnet: cid=1 version=19060
2026-01-04 13:49:50 I chat: *** [antibot] player '(1)ByFox' was caught cheating already.
```